### PR TITLE
ACT-35 Update hero to use hardcoded data when user not authorized

### DIFF
--- a/app/data/data.ts
+++ b/app/data/data.ts
@@ -1,0 +1,414 @@
+interface ResultItem {
+    basic_information: {
+        artists: (ArtistsEntity)[];
+        title: string;
+        cover_image: string;
+    }
+}
+
+interface ArtistsEntity {
+    name: string;
+}
+
+interface AlbumInfo {
+    coverImage: string;
+    title: string;
+    artist: string;
+}
+
+const data = [
+    {
+        "id": 5798599,
+        "instance_id": 1477450246,
+        "date_added": "2023-10-07T15:28:09-07:00",
+        "rating": 0,
+        "basic_information": {
+            "id": 5798599,
+            "master_id": 39247,
+            "master_url": "https://api.discogs.com/masters/39247",
+            "resource_url": "https://api.discogs.com/releases/5798599",
+            "thumb": "https://i.discogs.com/WkS5KdtLSLi1SgTLG7FSEUmonN6_AikpEjLvizKB0Mc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU3OTg1/OTktMTQwMjk3MDYy/NC04NTk3LmpwZWc.jpeg",
+            "cover_image": "https://i.discogs.com/TBs9Jkl2OVd11V_A0V2FjLInHI8jQsq7EGX4H1Y3b24/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU3OTg1/OTktMTQwMjk3MDYy/NC04NTk3LmpwZWc.jpeg",
+            "title": "End Of The Century",
+            "year": 1980,
+            "formats": [
+                {
+                    "name": "Vinyl",
+                    "qty": "1",
+                    "descriptions": [
+                        "LP",
+                        "Album"
+                    ]
+                }
+            ],
+            "artists": [
+                {
+                    "name": "Ramones",
+                    "anv": "",
+                    "join": "",
+                    "role": "",
+                    "tracks": "",
+                    "id": 135478,
+                    "resource_url": "https://api.discogs.com/artists/135478"
+                }
+            ],
+            "labels": [
+                {
+                    "name": "Sire",
+                    "catno": "SRK 6077",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 27031,
+                    "resource_url": "https://api.discogs.com/labels/27031"
+                }
+            ],
+            "genres": [
+                "Rock"
+            ],
+            "styles": [
+                "Rock & Roll",
+                "Punk"
+            ]
+        },
+        "folder_id": 1
+    },
+
+    {
+        "id": 20510521,
+        "instance_id": 1253150056,
+        "date_added": "2023-01-30T11:34:05-08:00",
+        "rating": 0,
+        "basic_information": {
+            "id": 20510521,
+            "master_id": 39289,
+            "master_url": "https://api.discogs.com/masters/39289",
+            "resource_url": "https://api.discogs.com/releases/20510521",
+            "thumb": "https://i.discogs.com/lHZHMeQrxGnZN4ErSRYmU-T6lzzdFoBXajUBG-QDz7s/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIwNTEw/NTIxLTE2MzM2NDk0/MzAtMzEwNS5qcGVn.jpeg",
+            "cover_image": "https://i.discogs.com/2eVJDIM_bZeDcFs-5DdueYWA7JcEPhkYE75G44CNIo4/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIwNTEw/NTIxLTE2MzM2NDk0/MzAtMzEwNS5qcGVn.jpeg",
+            "title": "Leave Home",
+            "year": 2018,
+            "formats": [
+                {
+                    "name": "Vinyl",
+                    "qty": "1",
+                    "text": "180g",
+                    "descriptions": [
+                        "LP",
+                        "Album",
+                        "Reissue",
+                        "Remastered"
+                    ]
+                }
+            ],
+            "artists": [
+                {
+                    "name": "Ramones",
+                    "anv": "",
+                    "join": "",
+                    "role": "",
+                    "tracks": "",
+                    "id": 135478,
+                    "resource_url": "https://api.discogs.com/artists/135478"
+                }
+            ],
+            "labels": [
+                {
+                    "name": "Sire",
+                    "catno": "RR1 6031",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 27031,
+                    "resource_url": "https://api.discogs.com/labels/27031"
+                },
+                {
+                    "name": "Rhino Records (2)",
+                    "catno": "081227940256",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 33244,
+                    "resource_url": "https://api.discogs.com/labels/33244"
+                }
+            ],
+            "genres": [
+                "Rock"
+            ],
+            "styles": [
+                "Rock & Roll",
+                "Punk"
+            ]
+        },
+        "folder_id": 1
+    },
+    {
+        "id": 11537893,
+        "instance_id": 1477448137,
+        "date_added": "2023-10-07T15:25:04-07:00",
+        "rating": 0,
+        "basic_information": {
+            "id": 11537893,
+            "master_id": 39289,
+            "master_url": "https://api.discogs.com/masters/39289",
+            "resource_url": "https://api.discogs.com/releases/11537893",
+            "thumb": "https://i.discogs.com/hD9gqdsqgZh7uN0_YNabuSw3oEIh0hJ4F7vSgA5N6w0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNTM3/ODkzLTE1NDE4MzYx/NTUtNDc5NS5qcGVn.jpeg",
+            "cover_image": "https://i.discogs.com/oj8MxGiQHKSMJXbbzTi5nMPBEmjJjuIkgpyyxWbkMzs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNTM3/ODkzLTE1NDE4MzYx/NTUtNDc5NS5qcGVn.jpeg",
+            "title": "Leave Home",
+            "year": 2018,
+            "formats": [
+                {
+                    "name": "Vinyl",
+                    "qty": "1",
+                    "text": "180gram",
+                    "descriptions": [
+                        "LP",
+                        "Album",
+                        "Reissue",
+                        "Remastered"
+                    ]
+                }
+            ],
+            "artists": [
+                {
+                    "name": "Ramones",
+                    "anv": "",
+                    "join": "",
+                    "role": "",
+                    "tracks": "",
+                    "id": 135478,
+                    "resource_url": "https://api.discogs.com/artists/135478"
+                }
+            ],
+            "labels": [
+                {
+                    "name": "Sire",
+                    "catno": "RR1 6031",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 27031,
+                    "resource_url": "https://api.discogs.com/labels/27031"
+                },
+                {
+                    "name": "Rhino Records (2)",
+                    "catno": "081227940256",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 33244,
+                    "resource_url": "https://api.discogs.com/labels/33244"
+                }
+            ],
+            "genres": [
+                "Rock"
+            ],
+            "styles": [
+                "Rock & Roll",
+                "Punk"
+            ]
+        },
+        "folder_id": 1
+    },
+    {
+        "id": 14107236,
+        "instance_id": 1477448404,
+        "date_added": "2023-10-07T15:25:29-07:00",
+        "rating": 0,
+        "basic_information": {
+            "id": 14107236,
+            "master_id": 39352,
+            "master_url": "https://api.discogs.com/masters/39352",
+            "resource_url": "https://api.discogs.com/releases/14107236",
+            "thumb": "https://i.discogs.com/XAFRZTaO65C_bwfK7Gz45W8iRA4qd8VWAemYHP8MeaE/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0MTA3/MjM2LTE1NzA1NDM5/MjgtODgyMy5qcGVn.jpeg",
+            "cover_image": "https://i.discogs.com/L0HtcEoXBktgbtLn0iG8i4JzGZHaAY6EK3fSmjE_lNM/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0MTA3/MjM2LTE1NzA1NDM5/MjgtODgyMy5qcGVn.jpeg",
+            "title": "Road To Ruin",
+            "year": 2019,
+            "formats": [
+                {
+                    "name": "Vinyl",
+                    "qty": "1",
+                    "text": "180 Gram",
+                    "descriptions": [
+                        "LP",
+                        "Album",
+                        "Reissue",
+                        "Remastered"
+                    ]
+                }
+            ],
+            "artists": [
+                {
+                    "name": "Ramones",
+                    "anv": "",
+                    "join": "",
+                    "role": "",
+                    "tracks": "",
+                    "id": 135478,
+                    "resource_url": "https://api.discogs.com/artists/135478"
+                }
+            ],
+            "labels": [
+                {
+                    "name": "Sire",
+                    "catno": "RR1 6063",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 27031,
+                    "resource_url": "https://api.discogs.com/labels/27031"
+                },
+                {
+                    "name": "Rhino Records (2)",
+                    "catno": "603497858262",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 33244,
+                    "resource_url": "https://api.discogs.com/labels/33244"
+                }
+            ],
+            "genres": [
+                "Rock"
+            ],
+            "styles": [
+                "Punk"
+            ]
+        },
+        "folder_id": 1
+    },
+    {
+        "id": 5160371,
+        "instance_id": 1477450513,
+        "date_added": "2023-10-07T15:28:35-07:00",
+        "rating": 0,
+        "basic_information": {
+            "id": 5160371,
+            "master_id": 39421,
+            "master_url": "https://api.discogs.com/masters/39421",
+            "resource_url": "https://api.discogs.com/releases/5160371",
+            "thumb": "https://i.discogs.com/Is4ob1ri_JHDagrl_dR4eUx1GdPS2JmNGdVv2ItylDM/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUxNjAz/NzEtMTM4NjEzNzgz/MC0yODA5LmpwZWc.jpeg",
+            "cover_image": "https://i.discogs.com/8BTYxCvlhMo9Co7m6bDbCz8FGHuptsGeygIBmGBZZkI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUxNjAz/NzEtMTM4NjEzNzgz/MC0yODA5LmpwZWc.jpeg",
+            "title": "Too Tough To Die",
+            "year": 1984,
+            "formats": [
+                {
+                    "name": "Vinyl",
+                    "qty": "1",
+                    "text": "Allied Pressing",
+                    "descriptions": [
+                        "LP",
+                        "Album"
+                    ]
+                }
+            ],
+            "artists": [
+                {
+                    "name": "Ramones",
+                    "anv": "",
+                    "join": "",
+                    "role": "",
+                    "tracks": "",
+                    "id": 135478,
+                    "resource_url": "https://api.discogs.com/artists/135478"
+                }
+            ],
+            "labels": [
+                {
+                    "name": "Sire",
+                    "catno": "1-25187",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 27031,
+                    "resource_url": "https://api.discogs.com/labels/27031"
+                },
+                {
+                    "name": "Sire",
+                    "catno": "9 25187-1",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 27031,
+                    "resource_url": "https://api.discogs.com/labels/27031"
+                }
+            ],
+            "genres": [
+                "Rock"
+            ],
+            "styles": [
+                "Punk"
+            ]
+        },
+        "folder_id": 1
+    },
+    {
+        "id": 11538003,
+        "instance_id": 1477447744,
+        "date_added": "2023-10-07T15:24:33-07:00",
+        "rating": 0,
+        "basic_information": {
+            "id": 11538003,
+            "master_id": 39341,
+            "master_url": "https://api.discogs.com/masters/39341",
+            "resource_url": "https://api.discogs.com/releases/11538003",
+            "thumb": "https://i.discogs.com/t3NOLP5GZyPC6tyJF1QYgna62HEYp4Lhe0lxMw-CKyE/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNTM4/MDAzLTE1MjIzMjMz/MjAtMjUxMi5qcGVn.jpeg",
+            "cover_image": "https://i.discogs.com/NFJPC_iwCHBQGizyV__C7e_CYEeob8Lr8U8p3ACpQ2o/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNTM4/MDAzLTE1MjIzMjMz/MjAtMjUxMi5qcGVn.jpeg",
+            "title": "Ramones",
+            "year": 2018,
+            "formats": [
+                {
+                    "name": "Vinyl",
+                    "qty": "1",
+                    "text": "180 Gram",
+                    "descriptions": [
+                        "LP",
+                        "Album",
+                        "Reissue",
+                        "Remastered",
+                        "Stereo"
+                    ]
+                }
+            ],
+            "artists": [
+                {
+                    "name": "Ramones",
+                    "anv": "",
+                    "join": "",
+                    "role": "",
+                    "tracks": "",
+                    "id": 135478,
+                    "resource_url": "https://api.discogs.com/artists/135478"
+                }
+            ],
+            "labels": [
+                {
+                    "name": "Sire",
+                    "catno": "RR1 6020",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 27031,
+                    "resource_url": "https://api.discogs.com/labels/27031"
+                },
+                {
+                    "name": "Sire",
+                    "catno": "081227932756",
+                    "entity_type": "1",
+                    "entity_type_name": "Label",
+                    "id": 27031,
+                    "resource_url": "https://api.discogs.com/labels/27031"
+                }
+            ],
+            "genres": [
+                "Rock"
+            ],
+            "styles": [
+                "Punk",
+                "Rock & Roll"
+            ]
+        },
+        "folder_id": 1
+    },
+]
+
+const formattedData = data.map((item: ResultItem): AlbumInfo => {
+    return {
+        artist: item.basic_information.artists[0].name,
+        title: item.basic_information.title,
+        coverImage: item.basic_information.cover_image,
+    }
+})
+
+
+export default formattedData;

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,7 +1,8 @@
-import Hero from '../hero'
-import getAlbumData from '../api/getAlbumData';
-import { currentUser } from '@clerk/nextjs';
-import Placeholder from './placeholder';
+import Hero from "../hero";
+import getAlbumData from "../api/getAlbumData";
+import { currentUser } from "@clerk/nextjs";
+import Placeholder from "./placeholder";
+import placeHolderData from "../data/data";
 
 export default async function Home() {
   let authorized = false;
@@ -10,23 +11,25 @@ export default async function Home() {
   let data;
   const user = await currentUser();
 
-  if (user?.privateMetadata.discogsToken && user?.privateMetadata.discogsUserId) {
+  if (
+    user?.privateMetadata.discogsToken &&
+    user?.privateMetadata.discogsUserId
+  ) {
     authorized = true;
     discogsToken = user?.privateMetadata.discogsToken as string;
     discogsUserId = user?.privateMetadata.discogsUserId as string;
     data = await getAlbumData(discogsToken, discogsUserId);
+  } else {
+    // For demo purposes, if user is not authorized with Discogs,
+    // show hardcoded data
+    data = placeHolderData;
   }
 
+  // To Do: Place holder for discogs syncing
+  // return <main>{authorized ? <Hero data={data} /> : <Placeholder />}</main>;
   return (
     <main>
-      {authorized ? (
-        <Hero data={data} />
-      ) : (
-        <Placeholder />
-      )
-
-      }
-
+      <Hero data={data} />
     </main>
-  )
+  );
 }


### PR DESCRIPTION
For demo purposes, added hardcoded data that can be used since syncing with discogs has not been added yet.